### PR TITLE
Fix Geyser max RAM parameter

### DIFF
--- a/site-cookbooks/minecraft/recipes/geyser.rb
+++ b/site-cookbooks/minecraft/recipes/geyser.rb
@@ -28,7 +28,7 @@ systemd_unit "geyser.service" do
     PrivateDevices=true
     NoNewPrivileges=true
     WorkingDirectory=#{gdir}
-    ExecStart=/usr/bin/java -Xmx#{jconf["g_xmx"]} -Xms#{jconf["xms"]} -jar geyser.jar nogui
+    ExecStart=/usr/bin/java -Xmx#{jconf["xmx"]} -Xms#{jconf["xms"]} -jar geyser.jar nogui
     [Install]
     WantedBy=multi-user.target
   EOU


### PR DESCRIPTION
Commit 38c935ca934 ("Rename attributes for geyser") did not change the
geyser recipe generation code back to use "xmx", and Geyser can't start.

Fix that.